### PR TITLE
Eliminate duplication when talking about officer terms.

### DIFF
--- a/organization/constitution
+++ b/organization/constitution
@@ -20,15 +20,13 @@ Article III - Officers
 
    Section 2 - Terms
 
-   Except for Trustee, the officers of this club shall be elected for a term of
-   one year.  The trustee shall be elected for a term of three years.  Officers
-   may be elected to the same position for consecutive terms.
+   Officer terms are indefinite, expiring only after another member is elected
+   into the position.  Officers may be elected to the same position for
+   consecutive terms.
 
    Section 3 - Election
 
-   Elections shall take place when called for by any full member. They shall be
-   performed in a manner provided for in the by-laws. Officer terms are indefinite,
-   expiring only after another member is elected into the position.
+   Elections shall take place when called for by any full member.
 
    Section 4 - Vacancies
 


### PR DESCRIPTION
We had the length of term listed in two places, and one place that
mentioned on year terms was still around.  Move the paragraph about
indefinite terms up into the terms section.